### PR TITLE
Fine-tuning Preferences' frontend to match backend logic

### DIFF
--- a/app/components/HeaderButtons.tsx
+++ b/app/components/HeaderButtons.tsx
@@ -2,14 +2,17 @@
 import { useRouter, usePathname } from "next/navigation";
 import { Button } from "antd";
 import { useEffect, useState, useRef } from "react";
-import { User } from "@/types/user";
+import { User, Preferences } from "@/types/user";
 import { useLogout } from "@/hooks/useLogout";
+import { useApi } from "@/hooks/useApi";
 
 export default function HeaderButtons() {
   const router = useRouter();
   const pathname = usePathname();
   const logout = useLogout();
+  const apiService = useApi();
   const [user, setUser] = useState<User | null>(null);
+  const [profilePicture, setProfilePicture] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -17,6 +20,18 @@ export default function HeaderButtons() {
     const storedUser = JSON.parse(localStorage.getItem("user") || "{}");
     if (storedUser?.id) {
       setUser(storedUser);
+
+      const fetchProfilePicture = async () => {
+        try {
+          const prefs = await apiService.get<Preferences>(
+            `/users/${storedUser.id}/preferences`
+          );
+          setProfilePicture(prefs.profilePicture ?? null);
+        } catch {
+          setProfilePicture(null);
+        }
+      };
+      fetchProfilePicture();
     }
   }, [pathname]);
 
@@ -85,9 +100,9 @@ export default function HeaderButtons() {
         }}>
           {user?.username ?? ""}
         </span>
-        {user?.profilePicture ? (
+        {profilePicture ? (
           <img
-            src={user.profilePicture}
+            src={profilePicture}
             alt={user?.username ?? ""}
             style={{ width: "80px", height: "80px", borderRadius: "50%", objectFit: "cover" }}
           />
@@ -102,7 +117,7 @@ export default function HeaderButtons() {
             justifyContent: "center",
             fontSize: "32px",
           }}>
-            🌍
+            👤
           </div>
         )}
       </div>

--- a/app/preferences/page.tsx
+++ b/app/preferences/page.tsx
@@ -9,8 +9,9 @@ import styles from "@/styles/register.module.css";
 import { useState, useRef, useEffect } from "react";
 
 interface FormFieldProps {
-  label: string;
-  value: string;
+  bio: string;
+  countries_visited: string[];
+  countries_wishlist: string[];
 }
 
 interface CountryApiItem {
@@ -70,15 +71,46 @@ const Preferences: React.FC = () => {
     };
   };
 
+  const [userPreferences, setUserPreferences] = useState<Record<string, string | null>>({});
+  useEffect(() => {
+    const fetchUsers = async () => {
+      try {
+        const response = await apiService.get<User[]>("/users");
+        setAllUsers(response);
+
+        const preferencesMap: Record<string, string | null> = {};
+        await Promise.all(
+          response.map(async (user) => {
+            try {
+              const prefs = await apiService.get<{ profilePicture: string }>(
+                `/users/${user.id}/preferences`
+              );
+              preferencesMap[user.id] = prefs.profilePicture ?? null;
+            } catch {
+              preferencesMap[user.id] = null;
+            }
+          })
+        );
+        setUserPreferences(preferencesMap);
+      } catch (error) {
+        console.error("Error fetching users:", error);
+      }
+    };
+    fetchUsers();
+  }, []);
+
   const handleEndRegistration = async (values: FormFieldProps) => {
     try {
       const storedUser = JSON.parse(localStorage.getItem("user") || "{}");
-      const payload = { ...values, profilePicture: imageBase64, friends: selectedFriends};
-      const response = await apiService.put<User>(`/users/${storedUser.id}`, payload);
-      if (response.token) {
-        setToken(response.token);
-        localStorage.setItem("user", JSON.stringify(response));
-      }
+
+      await apiService.post(`/users/${storedUser.id}/preferences`, {
+        bio: values.bio ?? null,
+        profilePicture: imageBase64 ?? null,
+        visitedCountries: values.countries_visited ?? null,
+        wishlistCountries: values.countries_wishlist ?? null,
+        friends: selectedFriends.map((id) => Number(id)) ?? null
+      });
+
       router.push(`/users/${storedUser.id}`);
     } catch (error) {
       if (error instanceof Error) {
@@ -106,9 +138,13 @@ const Preferences: React.FC = () => {
   }, []);
 
 
-  const filteredUsers = allUsers.filter((user) =>
-    user.username?.toLowerCase().includes(friendSearch.toLowerCase())
-  );
+  const filteredUsers = allUsers.filter((user) => {
+    const storedUser = JSON.parse(localStorage.getItem("user") || "{}");
+    return (
+      user.username?.toLowerCase().includes(friendSearch.toLowerCase()) &&
+      user.id !== storedUser.id
+    );
+  });
 
   return (
     <ConfigProvider
@@ -339,6 +375,8 @@ const Preferences: React.FC = () => {
                   ) : (
                     filteredUsers.map((user) => {
                       const isSelected = selectedFriends.includes(user.id);
+                      const profilePicture = userPreferences[user.id];
+
                       return (
                         <div
                           key={user.id}
@@ -358,9 +396,9 @@ const Preferences: React.FC = () => {
                           }}
                         >
                           {/* Profile picture */}
-                          {user.profilePicture ? (
+                          {profilePicture ? (
                             <img
-                              src={user.profilePicture}
+                              src={profilePicture}
                               alt={user.username}
                               style={{ width: 36, height: 36, borderRadius: "50%", objectFit: "cover" }}
                             />

--- a/app/types/user.ts
+++ b/app/types/user.ts
@@ -1,13 +1,17 @@
 export interface User {
   id: string;
-  name: string | null;
+  name?: string;
   username: string;
-  token: string | null;
-  status: string | null;
-  bio: string | null;
+  token?: string;
+  status?: string;
   creationDate: string;
-  profilePicture: string | null;
-  countriesVisited: string[] | null;
-  countriesWishlist: string[] | null;
-  friends: string[] | null;
+}
+
+export interface Preferences {
+  id: string;
+  bio?: string;
+  profilePicture?: string;
+  visitedCountries?: string[];
+  wishlistCountries?: string[];
+  friends?: number[];
 }


### PR DESCRIPTION
This pull request finalizes the frontend related to the following Preferences' user stories:
- differentiate user and preferences entities
- edit the preferences page so it matches the endpoint in backend
- restrict the current user from showing in the recommended users to add as friends
- show registered profile picture of user in the landing page (when logged-in) 